### PR TITLE
Metastor dm pagination 1250

### DIFF
--- a/metastor/managedObjectLoader/pom.xml
+++ b/metastor/managedObjectLoader/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<artifactId>metastore</artifactId>
 		<groupId>org.finra.herd-mdl.metastore</groupId>
-		<version>1.2.49</version>
+		<version>1.2.51</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/metastor/pom.xml
+++ b/metastor/pom.xml
@@ -29,13 +29,13 @@
 
 	<artifactId>metastore</artifactId>
 	<groupId>org.finra.herd-mdl.metastore</groupId>
-	<version>1.2.49</version>
+	<version>1.2.51</version>
 	<packaging>pom</packaging>
 
 	<properties>
 		<spring.boot.version>2.0.2.RELEASE</spring.boot.version>
 		<lombok.version>1.18.0</lombok.version>
-		<herd.sdk.version>0.97.0</herd.sdk.version>
+		<herd.sdk.version>0.149.0</herd.sdk.version>
 		<jcommander.version>1.72</jcommander.version>
 		<javax.json.version>1.1.2</javax.json.version>
 		<glassfish.version>1.1</glassfish.version>


### PR DESCRIPTION
The DM upgrade allows combining multiple ALTER statements for adding/dropping partitions (pagination). This is to allow METASTOR the ability to add/drop an object that has more than 50k partitions in a single DM call.
